### PR TITLE
Checkout submodules into the development workspace

### DIFF
--- a/devel-centos7/Dockerfile
+++ b/devel-centos7/Dockerfile
@@ -10,6 +10,8 @@ RUN echo '[local]\nlocalhost\n' > /etc/ansible/hosts
 RUN mkdir /opt/ansible/
 RUN git clone http://github.com/ansible/ansible.git /opt/ansible/ansible
 WORKDIR /opt/ansible/ansible
+RUN git submodule init
+RUN git submodule update
 ENV PATH /opt/ansible/ansible/bin:/bin:/usr/bin:/sbin:/usr/sbin
 ENV PYTHONPATH /opt/ansible/ansible/lib
 ENV ANSIBLE_LIBRARY /opt/ansible/ansible/library

--- a/devel-ubuntu14.04/Dockerfile
+++ b/devel-ubuntu14.04/Dockerfile
@@ -9,6 +9,8 @@ RUN echo '[local]\nlocalhost\n' > /etc/ansible/hosts
 RUN mkdir /opt/ansible/
 RUN git clone http://github.com/ansible/ansible.git /opt/ansible/ansible
 WORKDIR /opt/ansible/ansible
+RUN git submodule init
+RUN git submodule update
 ENV PATH /opt/ansible/ansible/bin:/bin:/usr/bin:/sbin:/usr/sbin
 ENV PYTHONPATH /opt/ansible/ansible/lib
 ENV ANSIBLE_LIBRARY /opt/ansible/ansible/library


### PR DESCRIPTION
For those that are not using the `stable` tags, the core and extra Ansible module repositories are not checked out into the development workspace for `latest` and `devel`, leading to unexpected syntax errors.
