### PR TITLE
Optimize stable-ubuntu14.04 Dockerfile

### DIFF
--- a/stable-ubuntu14.04/Dockerfile
+++ b/stable-ubuntu14.04/Dockerfile
@@ -1,9 +1,11 @@
 # Latest Ubuntu LTS
 FROM ubuntu:14.04
 MAINTAINER Toshio Kuratomi <tkuratomi@ansible.com>
-RUN apt-get -y update
-RUN apt-get -y upgrade
-RUN apt-get install -y python-yaml python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools python-pkg-resources git python-pip
-RUN mkdir /etc/ansible/
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y software-properties-common && \
+    apt-add-repository ppa:ansible/ansible && \
+    apt-get update && \
+    apt-get install -y ansible
+
 RUN echo '[local]\nlocalhost\n' > /etc/ansible/hosts
-RUN pip install ansible
+


### PR DESCRIPTION
Hi,
as far as I know, best practise for docker seems to avoid running apt-get upgrade.
The base image (in this case ubuntu:14.04) is responsible for upgrades.

Second, having several run commands for apt creates unnecessary layers in the final docker image, it would be better to do something like
   RUN apt-get -y update &&  apt-get install [...]

One last thing I want to discuss:
Installing ansible with pip really pulls a lot of dependencies. 
The size of the final image decreases from 413.4 MB to 292.6 MB with this pull request. (The base image ubuntu:14.04 is 197.8 MB).
And at least for the stable version I prefer using the repository ppa:ansible/ansible.

Best regards,
Martin Schmidt
